### PR TITLE
Update supply-chain.yaml

### DIFF
--- a/content/docs/v0.5.0/tutorials/files/extending-a-supply-chain/supply-chain.yaml
+++ b/content/docs/v0.5.0/tutorials/files/extending-a-supply-chain/supply-chain.yaml
@@ -4,9 +4,6 @@ kind: ClusterSupplyChain
 metadata:
   name: source-code-supply-chain
 spec:
-  selector:
-    workload-type: source-code
-
   resources:
     - name: build-image
       templateRef:
@@ -23,3 +20,6 @@ spec:
   serviceAccountRef:
     name: cartographer-from-source-sa
     namespace: default
+
+  selector:
+    workload-type: source-code


### PR DESCRIPTION
Move the selector part down to match the structure as used in the supply-chain.yaml file of the "first supply chain" directory example (introduced earlier in the documentation) (https://github.com/vmware-tanzu/cartographer-site/blob/main/content/docs/v0.5.0/tutorials/files/first-supply-chain/supply-chain.yaml).